### PR TITLE
SWP-100925 [ProxySQL helm] allow arbitrary use of @include for secrets injection

### DIFF
--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -69,12 +69,15 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `podDisruptionBudget.maxUnavailable`        | Maximum number / percentage of pods that may be made unavailable | 
 | `admin_variables.admin_credentials`         | ProxySQL admin credentials for the management (127.0.0.1:6032)  | `admin:admin`                                         |
 | `admin_variables.debug`                     | ProxySQL debug mode                                | `false`                                                            |
+| `admin_variables_include`                   | A list of files to @include in the `admin_variables` section | `[]`                                                     |
 | `mysql_variables.threads`                   | The number of background threads that ProxySQL uses in order to process MySQL traffic. | `4`                            |
 | `mysql_variables.max_connections`           | The maximum number of client connections that the proxy can handle. | `2048`                                            |
 | `mysql_variables.default_query_delay`       | Simple throttling mechanism for queries to the backends. Setting this variable to a non-zero value (in miliseconds) will delay the execution of all queries, globally.                                     | `0`                                                |
 | `mysql_variables.default_query_timeout`     | Mechanism for specifying the maximal duration of queries to the backend MySQL servers until ProxySQL should return an error to the MySQL client.                                                                 | `3600000` milliseconds                             |
 | `mysql_variables.monitor`                   | Enables or disables MySQL Monitor module.           | `false`                                                           |
+| `mysql_variables_include`                   | A list of files to @include in the `mysql_variables` section | `[]`                                                     |
 | `mysql_users`                               | Defines ProxySQL [users configuration](https://github.com/sysown/proxysql/wiki/Users-configuration)         | `[]`      |
+| `mysql_users_include`                       | A list of files to @include in the `mysql_users` section | `[]`                                                         |
 | `mysql_servers`                             | Defines ProxySQL [backend servers configuration](https://github.com/sysown/proxysql/wiki/MySQL-Server-Configuration) | `[]`  |
 | `mysql_query_rules`                         | Defines ProxySQL [Query Rules (routing)] (https://github.com/sysown/proxysql#configuring-proxysql-through-the-config-file) | `[]`  |
 | `ssl.auto`                                  | Automatically set `use_ssl` to `1` when the SSL configuration is provided | `true`  |

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -2,7 +2,12 @@ datadir="/var/lib/proxysql"
 
 admin_variables=
 {
+  {{- range $include := .Values.admin_variables_include}}
+  @include "{{ $include }}"
+  {{- end }}
+  {{- if not .Values.admin_variables_include}}
   @include "/etc/proxysql/admin_credentials.cnf"
+  {{- end}}
   {{- if .Values.admin_variables.mysql_ifaces }}
   interfaces={{ .Values.admin_variables.mysql_ifaces | quote }}
   {{- else }}
@@ -15,6 +20,9 @@ admin_variables=
 
 mysql_variables=
 {
+  {{- range $include := .Values.mysql_variables_include}}
+  @include "{{ $include }}"
+  {{- end }}
   {{/* ProxySQL SSL config */}}
   {{- if .Values.ssl.fromSecret }}
   ssl_p2s_ca="{{ include "proxysql.sslDir" . }}/{{ .Values.ssl.ca_file }}"
@@ -52,6 +60,9 @@ mysql_servers =
 
 mysql_users:
 (
+  {{- range $include := .Values.mysql_users_include}}
+  @include "{{ $include }}"
+  {{- end }}
   {{- range $_, $user := .Values.mysql_users }}
   {
     {{- if hasKey $user "active" -}}

--- a/dysnix/proxysql/tests/configmap-include-directives_test.yaml
+++ b/dysnix/proxysql/tests/configmap-include-directives_test.yaml
@@ -1,0 +1,39 @@
+suite: configmap
+templates:
+  - configmap.yaml
+
+tests:
+  - it: admin_variables include
+    values:
+      - ./values/common.yaml
+      - ./values/admin-variables-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/admin_vars\.cnf"'
+
+      # our includes should replace the insecure creds include
+      - notMatchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/admin_credentials\.cnf"'
+
+  - it: mysql_variables include
+    values:
+      - ./values/common.yaml
+      - ./values/mysql-variables-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/mysql_vars\.cnf"'
+
+  - it: mysql_users include
+    values:
+      - ./values/common.yaml
+      - ./values/mysql-users-include.yaml
+
+    asserts:
+      - matchRegex:
+          path: .data["proxysql.cnf"]
+          pattern: '@include "/etc/proxysql/secrets/mysql_users\.cnf"'

--- a/dysnix/proxysql/tests/values/admin-variables-include.yaml
+++ b/dysnix/proxysql/tests/values/admin-variables-include.yaml
@@ -1,0 +1,2 @@
+admin_variables_include:
+  - /etc/proxysql/secrets/admin_vars.cnf

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -75,6 +75,8 @@ secret:
 admin_variables:
   debug: false
 
+admin_variables_include: []
+
 mysql_variables:
   threads: 4
 
@@ -84,7 +86,11 @@ mysql_variables:
   default_query_timeout: 3600000
   monitor_enabled: false
 
+mysql_variables_include: []
+
 mysql_users:
+
+mysql_users_include: []
 
 mysql_servers:
 

--- a/dysnix/proxysql/tests/values/mysql-users-include.yaml
+++ b/dysnix/proxysql/tests/values/mysql-users-include.yaml
@@ -1,0 +1,2 @@
+mysql_users_include:
+  - /etc/proxysql/secrets/mysql_users.cnf

--- a/dysnix/proxysql/tests/values/mysql-variables-include.yaml
+++ b/dysnix/proxysql/tests/values/mysql-variables-include.yaml
@@ -1,0 +1,2 @@
+mysql_variables_include:
+  - /etc/proxysql/secrets/mysql_vars.cnf

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -188,6 +188,11 @@ admin_variables:
 
   # refresh_interval: 2000
 
+## A list of files to @include in the `admin_variables` section
+##
+admin_variables_include: []
+#   - /etc/proxysql/secrets/admin_vars.cnf
+
 mysql_variables:
   ## ref: https://github.com/sysown/proxysql/wiki/Global-variables
   #
@@ -212,6 +217,11 @@ mysql_variables:
   # monitor_password: "monitor"
   # monitor_history: 600000
 
+## A list of files to @include in the `mysql_variables` section
+##
+mysql_variables_include: []
+#   - /etc/proxysql/secrets/mysql_vars.cnf
+
 ## Configures ProxySQL mysql users.
 #  For MySQL 8.0 paswords must be mysql_native_password.
 #  ref: https://github.com/sysown/proxysql/wiki/MySQL-8.0
@@ -223,6 +233,11 @@ mysql_users:
   #   max_connections: 200
   #   default_schema: "information_schema"
   #   active: 1
+
+## A list of files to @include in the `mysql_users` section
+##
+mysql_users_include: []
+#   - /etc/proxysql/secrets/mysql_users.cnf
 
 ## Define MySQL backend servers
 #


### PR DESCRIPTION
Inject secrets mounted to the container by using @include directive in the ProxySQL config