### PR TITLE
[FIX] SWP-100922   [ProxySQL helm] allow arbitrary `volumes` and `volumeMounts` for pods

### DIFF
--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -82,6 +82,8 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `ssl.cert`                                  | ProxySQL SSL certificate | `""`  |
 | `ssl.key`                                   | ProxySQL SSL key | `""`  |
 | `ssl.fromSecret`                            | Specify a secret containing `ca.pem`, `cert.pem` and `key.pem` SSL configuration | `""`  |
+| `volumes`                                   | Configure volumes for the ProxySQL pods | `[]`                                                                          |
+| `volumeMounts`                              | Configure volumeMounts for the ProxySQL container | `[]`                                                                |
 
 For more information please refer to the proxysql [config file](https://github.com/sysown/proxysql#configuring-proxysql-through-the-config-file) and [global variables](https://github.com/sysown/proxysql/wiki/Global-variables).
 

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -86,6 +86,9 @@ spec:
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: data
               mountPath: /data/proxysql
             - name: conf
@@ -160,6 +163,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | int }}
       volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: data
           emptyDir: {}
         - name: secrets

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -87,6 +87,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: data
               mountPath: /data/proxysql
             - name: conf
@@ -161,6 +164,9 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | int }}
       volumes:
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: data
           emptyDir: {}
         - name: secrets

--- a/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/daemonset-volumes-and-volumemounts_test.yaml
@@ -1,0 +1,39 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+
+tests:
+  - it: pod volumes correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumes.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: DaemonSet
+
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: admin-vars
+            secret:
+              secretName: admin-vars
+
+  - it: proxysql container volumeMounts correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumeMounts.yaml
+    set: *sets
+
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: admin-vars
+            mountPath: /etc/proxysql/admin_vars.cnf
+            subPath: admin_vars.cnf

--- a/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
+++ b/dysnix/proxysql/tests/deployment-volumes-and-volumemounts_test.yaml
@@ -1,0 +1,39 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+
+tests:
+  - it: pod volumes correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumes.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: Deployment
+
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: admin-vars
+            secret:
+              secretName: admin-vars
+
+  - it: proxysql container volumeMounts correct
+    values:
+      - ./values/common.yaml
+      - ./values/volumeMounts.yaml
+    set: *sets
+
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: admin-vars
+            mountPath: /etc/proxysql/admin_vars.cnf
+            subPath: admin_vars.cnf

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -21,15 +21,18 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-# volumes:
-#   - name: admin-vars
+## Configure volumes for the ProxySQL pods
+##
+volumes: []
+#   - name: secret-confs
 #     secret:
-#       secretName: admin-vars
+#       secretName: secret-confs
 
-# volumeMounts:
-#   - name: secrets
-#     mountPath: /etc/proxysql/admin_vars.cnf
-#     subPath: admin_vars.cnf
+## Configure volumeMounts for the ProxySQL container
+##
+volumeMounts: []
+#   - name: secret-confs
+#     mountPath: /etc/proxysql/secrets
 
 podSecurityContext:
   runAsNonRoot: true


### PR DESCRIPTION
Here's a few fixes for the volumes and volumeMounts feature
* expand support to DaemonSet and Deployment
* set correct defaults
* improve documentation