### PR TITLE
SWP-100924   [ProxySQL helm] allow customization of readiness and liveness probes

### DIFF
--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -52,6 +52,8 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `image.tag`                                 | ProxySQL Image tag                                   | `2.0.9`                                                          |
 | `image.pullPolicy`                          | ProxySQL image pull policy                           | `IfNotPresent`                                                   |
 | `image.pullSecrets`                         | Specify docker-registry secret names as an array    | `[]` (does not add image pull secrets to deployed pods)           |
+| `livenessProbe`                             | Specify livenessProbe for ProxySQL container | `{}`                                                                     |
+| `readinessProbe`                            | Specify readinessProbe for ProxySQL container | (see values.yaml)                                                       |
 | `nameOverride`                              | String to partially override proxysql.fullname template with a string (will prepend the release name) | `nil`            |
 | `fullnameOverride`                          | String to fully override proxysql.fullname template with a string                                     | `nil`            |
 | `service.type`                              | Kubernetes service type                             | `ClusterIP`                                                       |

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -73,15 +73,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.satellite.daemonset.resources) | nindent 12 }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -74,15 +74,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -75,15 +75,11 @@ spec:
             - name: web
               containerPort: {{ .Values.service.webPort }}
               protocol: TCP
-          {{- if .Values.readinessProbe.enabled }}
-          readinessProbe:
-            exec:
-              command: ["bash", "-c", "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"]
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
             {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}

--- a/dysnix/proxysql/tests/daemonset-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/daemonset-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: daemonset
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - daemonset.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: DaemonSet
+
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/deployment-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/deployment-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: deployment
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: true
+      proxysql_cluster.satellite.kind: Deployment
+
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/statefulset-liveness-readiness-probes_test.yaml
+++ b/dysnix/proxysql/tests/statefulset-liveness-readiness-probes_test.yaml
@@ -1,0 +1,48 @@
+suite: statefulset
+templates:
+  - configmap-scripts.yaml
+  - configmap.yaml
+  - secret.yaml
+  - statefulset.yaml
+
+tests:
+  - it: readinessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/readinessprobe.yaml
+    set: &sets
+      proxysql_cluster.satellite.enabled: false
+      proxysql_cluster.enabled: true
+
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe
+          value:
+            exec:
+              command:
+                - "bash"
+                - "-c"
+                - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+  - it: livenessProbe correct
+    values:
+      - ./values/common.yaml
+      - ./values/livenessprobe.yaml
+    set: *sets
+
+    asserts:
+      - template: statefulset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe
+          value:
+            exec:
+              command:
+                - sh
+                - "-c"
+                - uptime

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -49,13 +49,14 @@ podLabels: {}
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
+
 readinessProbe:
-  enabled: true
   initialDelaySeconds: 5
   periodSeconds: 10
   timeoutSeconds: 1
   successThreshold: 1
   failureThreshold: 3
+
 ssl:
   auto: true
   ca: ""

--- a/dysnix/proxysql/tests/values/livenessprobe.yaml
+++ b/dysnix/proxysql/tests/values/livenessprobe.yaml
@@ -1,0 +1,6 @@
+livenessProbe:
+  exec:
+    command:
+      - sh
+      - "-c"
+      - uptime

--- a/dysnix/proxysql/tests/values/readinessprobe.yaml
+++ b/dysnix/proxysql/tests/values/readinessprobe.yaml
@@ -1,0 +1,11 @@
+readinessProbe:
+  exec:
+    command:
+      - "bash"
+      - "-c"
+      - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -142,7 +142,11 @@ podDisruptionBudget:
   # maxUnavailable: 1
 
 readinessProbe:
-  enabled: true
+  exec:
+    command:
+      - "bash"
+      - "-c"
+      - "true <>/dev/tcp/127.0.0.1/{{ .Values.service.proxyPort }}"
   initialDelaySeconds: 5
   ##
   ## Default Kubernetes values
@@ -150,6 +154,14 @@ readinessProbe:
   timeoutSeconds: 1
   successThreshold: 1
   failureThreshold: 3
+
+livenessProbe:
+  {}
+  # exec:
+  #   command:
+  #     - sh
+  #     - "-c"
+  #     - uptime
 
 # Enable SSL communication with the backend MySQL servers
 ssl:


### PR DESCRIPTION
Let's allow fully customizable readiness and liveness probes.  NOTE: This change preserves the existing default readiness check command via default values in `values.yaml`