### PR TITLE
New release: proxysql-0.10.2-splashthat-rc2

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc1
+version: 0.10.2-splashthat-rc2
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts


### PR DESCRIPTION
The previous `release` run attempted to build _every_ chart.  Let's see if this one will only target this chart.