### PR TITLE
SWP-101006   [ProxySQL helm] allow MySQL port on "core" service

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc2
+version: 0.10.2-splashthat-rc3
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -70,6 +70,14 @@ metadata:
     {{- end }}
 spec:
   ports:
+    {{- if .Values.proxysql_cluster.core.service.exposeProxyPort }}
+    - name: proxy
+      port: {{ .Values.service.proxyPort }}
+      targetPort: proxy
+      {{- if .Values.service.proxyNodePort }}
+      nodePort: {{ .Values.service.proxyNodePort }}
+      {{- end }}
+    {{- end }}
     - name: admin
       port: {{ .Values.service.adminPort }}
       targetPort: admin

--- a/dysnix/proxysql/tests/service-core-expose-proxy-port_test.yaml
+++ b/dysnix/proxysql/tests/service-core-expose-proxy-port_test.yaml
@@ -1,0 +1,37 @@
+suite: service
+templates:
+  - service.yaml
+
+tests:
+  - it: core service default no proxy port
+    documentIndex: 1
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+
+    asserts:
+      - notContains:
+          path: spec.ports
+          content:
+            name: proxy
+            port: 6033
+            targetPort: proxy
+
+  - it: core service expose proxy port correct
+    documentIndex: 1
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+      proxysql_cluster.core.service.exposeProxyPort: true
+
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: proxy
+            port: 6033
+            targetPort: proxy

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -123,6 +123,7 @@ proxysql_cluster:
 
     service:
       name:
+      exposeProxyPort: false
 
   satellite:
     kind: "DaemonSet"

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -331,7 +331,7 @@ proxysql_cluster:
     service:
       # Override default core service name
       name:
-      # Expose the proxy (to MySQL servers) port 
+      # Expose the proxy (to MySQL servers) port
       exposeProxyPort: false
 
   satellite:

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -331,6 +331,8 @@ proxysql_cluster:
     service:
       # Override default core service name
       name:
+      # Expose the proxy (to MySQL servers) port 
+      exposeProxyPort: false
 
   satellite:
     # Select the Kubernetes Resource type for the Satellite nodes,


### PR DESCRIPTION
Allow exposing the proxy port (6033) on the "core" service.  This allows users to explore a "core-only" deployment.