### PR TITLE
SWP-101022   [ProxySQL helm] use correct hostname in proxysql.cnf

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc3
+version: 0.10.2-splashthat-rc4
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -94,7 +94,7 @@ proxysql_servers=
   {{- $coreServiceName := printf "%s-core" (include "proxysql.fullname" .) }}
   {{- range $index, $_ := until $nodeCount }}
   {
-    hostname={{ printf "proxysql-core-%d.%s" $index $coreServiceName | toJson }}
+    hostname={{ printf "%s-%d.%s" $coreServiceName $index $coreServiceName | toJson }}
     port={{ $.Values.service.adminPort | toJson }}
     weight=100
   },

--- a/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
+++ b/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
@@ -1,0 +1,18 @@
+suite: configmap
+templates:
+  - configmap.yaml
+
+tests:
+  - it: proxysql_servers correct
+    values:
+      - ./values/common.yaml
+      - ./values/proxysql-servers.yaml
+
+    asserts:
+      - matchRegex:
+          path: data.[proxysql.cnf]
+          # NOTE: the renderer organizes the keys in alphabetical order
+          pattern: |
+            \s+hostname="foobar-test-core-0.foobar-test-core"
+            \s+port=6032
+            \s+weight=100

--- a/dysnix/proxysql/tests/values/proxysql-servers.yaml
+++ b/dysnix/proxysql/tests/values/proxysql-servers.yaml
@@ -1,0 +1,1 @@
+fullnameOverride: foobar-test


### PR DESCRIPTION
The pod hostnames were hardcoded which only works if the release name matches the hardcoding.