### PR TITLE
SWP-101024   [ProxySQL helm] tidy up config syntax and docs

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.4.4"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc4
+version: 0.10.2-splashthat-rc5
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/README.md
+++ b/dysnix/proxysql/README.md
@@ -69,6 +69,51 @@ The following table lists the configurable parameters of the ProxySQL chart and 
 | `podDisruptionBudget.enabled`               | If true, create a pod disruption budget for master pods. | `false`                                                      |
 | `podDisruptionBudget.minAvailable`          | Minimum number / percentage of pods that should remain scheduled | `1`                                                  |
 | `podDisruptionBudget.maxUnavailable`        | Maximum number / percentage of pods that may be made unavailable | 
+| `proxysql_cluster.core.enabled` | Deploy core ProxySQL workload | `true`
+| `proxysql_cluster.core.exit_on_error` | Restart ProxySQL if crashes | `false`
+| `proxysql_cluster.core.replicas` | Number of core/main ProxySQL nodes to listen on | `3`
+| `proxysql_cluster.core.service.exposeProxyPort` | Expose the proxy (to MySQL servers) port | `false`
+| `proxysql_cluster.core.service.name` | Override default core service name | `nil`
+| `proxysql_cluster.core.statefulset.affinity` | Set core Pod affinity | `{}`
+| `proxysql_cluster.core.statefulset.nodeSelector` | Set core Pod node selector | `{}`
+| `proxysql_cluster.core.statefulset.podAnnotations` | Set core Pod annotations | `{}`
+| `proxysql_cluster.core.statefulset.resources` | Set core Pod resources (requests and limits) | `{}`
+| `proxysql_cluster.core.statefulset.tolerations` | Set core Pod tolerations | `[]`
+| `proxysql_cluster.enabled` | Deploy ProxySQL (clustered) workloads | `false` | 
+| `proxysql_cluster.healthcheck.sidecar.command` | Command to run for healthcheck sidecar | `["/usr/local/bin/proxysql_cluster_healthcheck.sh"]`
+| `proxysql_cluster.healthcheck.sidecar.config.diff_check_limit` | How many diff_check errors are tolerated before the healthcheck fails | `10`
+| `proxysql_cluster.healthcheck.sidecar.config.kill_if_healthcheck_failed` | Kill proxysql daemon if the healthcheck fails the test | `true`
+| `proxysql_cluster.healthcheck.sidecar.config.psql_host` | The listening core host/pod | `"127.0.0.1"`
+| `proxysql_cluster.healthcheck.sidecar.config.psql_host_port` | The admin port | `6032`
+| `proxysql_cluster.healthcheck.sidecar.config.psql_pass` | Monitor user | `"monitor"`
+| `proxysql_cluster.healthcheck.sidecar.config.psql_user` | Monitor password | `"monitor"`
+| `proxysql_cluster.healthcheck.sidecar.enabled` | Inject a healthcheck sidecar container to all proxysql clustering Pods | `false`
+| `proxysql_cluster.healthcheck.sidecar.image` | Container image | `"mysql:debian"`
+| `proxysql_cluster.healthcheck.sidecar.securityContext` | Set healthcheck sidecar security context | (see values.yaml)
+| `proxysql_cluster.job.affinity` | Set Job affinity | `{}`
+| `proxysql_cluster.job.backoffLimit` | Set Job backoff limit | `3`
+| `proxysql_cluster.job.enabled` | Deploy Kubernetes Job to initialize cluster | `true`
+| `proxysql_cluster.job.image.pullPolicy` | Set Job image pull policy | `"IfNotPresent"`
+| `proxysql_cluster.job.image.registry` | Set Job image registry | `"docker.io"`
+| `proxysql_cluster.job.image.repository` | Set Job image repository | `"mysql"`
+| `proxysql_cluster.job.image.tag` | Set Job image tag | `"8"`
+| `proxysql_cluster.job.nodeSelector` | Set Job Pod node selector | `{}`
+| `proxysql_cluster.job.podAnnotations` | Set Job Pod annotations | `{}`
+| `proxysql_cluster.job.resources` | Set Job Pod resources (requests and limits) | `{}`
+| `proxysql_cluster.job.tolerations` | Set Job Pod tolerations | `[]`
+| `proxysql_cluster.job.ttlSecondsAfterFinished` | Set Job time-to-live seconds after finished | `3600`
+| `proxysql_cluster.satellite.daemonset.affinity` | Set DaemonSet Pod affinity | `{}`
+| `proxysql_cluster.satellite.daemonset.nodeSelector` | Set DaemonSet Pod node selector | `{}`
+| `proxysql_cluster.satellite.daemonset.podAnnotations` | Set DaemonSet Pod annotations | `{}`
+| `proxysql_cluster.satellite.daemonset.resources` | Set DaemonSet Pod resources (requests and limits) | `{}`
+| `proxysql_cluster.satellite.daemonset.tolerations` | Set DaemonSet Pod tolerations | `[]`
+| `proxysql_cluster.satellite.enabled` | Deploy satellite ProxySQL workload | `true`
+| `proxysql_cluster.satellite.exit_on_error` | Job Pod | `false`
+| `proxysql_cluster.satellite.kind` | Workload type for satellite ProxySQL | `"DaemonSet"`
+| `proxysql_cluster.satellite.replicas` | Number of satellite ProxySQL nodes to listen on | `3`
+| `proxysql_cluster.satellite.service.name` | Override default satellite service name | `nil`
+| `proxysql_cluster.secret.cluster_password` | This are the variables to set `admin_credentials` and corresponding `cluster_` variables | `"proxysql"`
+| `proxysql_cluster.secret.cluster_username` | This are the variables to set `admin_credentials` and corresponding `cluster_` variables | `"proxysql-cluster"`
 | `admin_variables.admin_credentials`         | ProxySQL admin credentials for the management (127.0.0.1:6032)  | `admin:admin`                                         |
 | `admin_variables.debug`                     | ProxySQL debug mode                                | `false`                                                            |
 | `admin_variables_include`                   | A list of files to @include in the `admin_variables` section | `[]`                                                     |

--- a/dysnix/proxysql/files/proxysql.cnf
+++ b/dysnix/proxysql/files/proxysql.cnf
@@ -58,7 +58,7 @@ mysql_servers =
   {{- end }}
 )
 
-mysql_users:
+mysql_users=
 (
   {{- range $include := .Values.mysql_users_include}}
   @include "{{ $include }}"
@@ -75,7 +75,7 @@ mysql_users:
   {{- end }}
 )
 
-mysql_query_rules:
+mysql_query_rules=
 (
   {{- range $idx, $rule := .Values.mysql_query_rules }}
   {
@@ -114,7 +114,7 @@ scheduler=
 (
   {{- range $idx, $rule := .Values.scheduler }}
   {
-    rule_id={{ add $idx 1 }}
+    id={{ add $idx 1 }}
     {{- range $key, $value := $rule }}
     {{ $key }}={{ $value | toJson }}
     {{- end }}
@@ -126,7 +126,6 @@ mysql_replication_hostgroups=
 (
   {{- range $idx, $rule := .Values.mysql_replication_hostgroups }}
   {
-    rule_id={{ add $idx 1 }}
     {{- range $key, $value := $rule }}
     {{ $key }}={{ $value | toJson }}
     {{- end }}

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -25,7 +25,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/config.scripts: {{ include (print $.Template.BasePath "/configmap-scripts.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- with (mergeOverwrite .Values.podAnnotations .Values.proxysql_cluster.core.statefullset.podAnnotations) }}
+        {{- with (mergeOverwrite .Values.podAnnotations .Values.proxysql_cluster.core.statefulset.podAnnotations) }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
@@ -82,7 +82,7 @@ spec:
           readinessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}
           resources:
-            {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefullset.resources) | nindent 12 }}
+            {{- toYaml (default .Values.resources .Values.proxysql_cluster.core.statefulset.resources) | nindent 12 }}
           volumeMounts:
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -147,15 +147,15 @@ spec:
             {{- toYaml .| nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- with (default .Values.nodeSelector .Values.proxysql_cluster.core.statefullset.nodeSelector) }}
+      {{- with (default .Values.nodeSelector .Values.proxysql_cluster.core.statefulset.nodeSelector) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with (default .Values.affinity .Values.proxysql_cluster.core.statefullset.affinity) }}
+    {{- with (default .Values.affinity .Values.proxysql_cluster.core.statefulset.affinity) }}
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with (default .Values.tolerations .Values.proxysql_cluster.core.statefullset.tolerations) }}
+    {{- with (default .Values.tolerations .Values.proxysql_cluster.core.statefulset.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/dysnix/proxysql/tests/values/common.yaml
+++ b/dysnix/proxysql/tests/values/common.yaml
@@ -113,7 +113,7 @@ proxysql_cluster:
     replicas: 3
     exit_on_error: false
 
-    statefullset:
+    statefulset:
       nodeSelector: {}
       tolerations: []
       affinity: {}

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -281,7 +281,7 @@ scheduler:
   #   comment: "job to cleanup stats_mysql_query_digest table"
 
 ## If enabled, generate automagically a list of proxysql servers based on the
-#    the number statefullset 'proxysql-core' replicas (default 3).
+#    the number statefulset 'proxysql-core' replicas (default 3).
 use_default_proxysql_servers: true
 
 ## Defines an additional list of ProxySQL peers (clustering).
@@ -314,7 +314,7 @@ proxysql_cluster:
     # Restart ProxySQL if crashes
     exit_on_error: false
 
-    statefullset:
+    statefulset:
       nodeSelector: {}
       tolerations: []
       affinity: {}


### PR DESCRIPTION
There are a few issues with documentation and proxysql.cnf syntax:

* `mysql_query_rules and mysql_users` use `:` when they should use `=`
* `scheduler` uses `rule_id` when it should use `id`
* `mysql_replication_hostgroups` uses `rule_id` but doesn’t need any IDs
* `proxysql_cluster.*` have no documentation
* `statefulset` is misspelled as `statefullset`