### PR TITLE
[SWP-103641] target core in service when satellite is disabled

### DIFF
--- a/.github/scripts/unit-test.sh
+++ b/.github/scripts/unit-test.sh
@@ -39,7 +39,7 @@ export charts_dir="${1:-charts/}"
 
 echo 'Fetching tools'
 apk add --no-cache git yq
-git config --global --add safe.directory /github/workspace
+git config --global --add safe.directory /apps
 
 echo 'Looking up latest tag...'
 latest_tag=$(lookup_latest_tag)
@@ -51,7 +51,7 @@ if [ -n "$changed_charts" ]; then
     for chart in $changed_charts; do
         if (ls -1 "$chart"/tests/*_test.yaml 1>/dev/null 2>/dev/null); then
             helm dependency update "$chart" 
-            helm unittest --color --helm3 "$chart"
+            helm unittest --color "$chart"
         fi
     done
 fi

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -9,12 +9,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
+      - # Here we need to run the container as root to be able to add additional packages
         name: Run helmunittest/helm-unittest
-        uses: docker://helmunittest/helm-unittest:3.13.1-0.3.6
-        with:
-          entrypoint: ./.github/scripts/unit-test.sh
-          args: dysnix/
+        run: |
+          docker run \
+          --rm \
+          -u root \
+          -v $PWD:/apps \
+          -w /apps \
+          --entrypoint .github/scripts/unit-test.sh \
+          helmunittest/helm-unittest:3.13.1-0.3.6 \
+          dysnix/
 
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -10,8 +10,8 @@ jobs:
         with:
           fetch-depth: 0
       -
-        name: Run quintush/helm-unittest
-        uses: docker://quintush/helm-unittest:3.10.1-0.2.10
+        name: Run helmunittest/helm-unittest
+        uses: docker://helmunittest/helm-unittest:3.13.1-0.3.6
         with:
           entrypoint: ./.github/scripts/unit-test.sh
           args: dysnix/

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.2-splashthat-rc8
+version: 0.10.2-splashthat-rc9
 home: https://www.proxysql.com/
 sources:
   - https://github.com/dysnix/charts

--- a/dysnix/proxysql/templates/service.yaml
+++ b/dysnix/proxysql/templates/service.yaml
@@ -54,7 +54,11 @@ spec:
       nodePort: {{ .Values.service.restapiNodePort }}
       {{- end }}
   selector:
+    {{- if .Values.proxysql_cluster.satellite.enabled }}
     app: {{ include "proxysql.name" . }}
+    {{- else }}
+    app: {{ include "proxysql.name" . }}-core
+    {{- end }}
     release: {{ .Release.Name }}
 ---
 {{ if and .Values.proxysql_cluster.enabled .Values.proxysql_cluster.core.enabled }}

--- a/dysnix/proxysql/tests/configmap-expose-restapi-port_test.yaml
+++ b/dysnix/proxysql/tests/configmap-expose-restapi-port_test.yaml
@@ -9,7 +9,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: \s+restapi_port\s*=\s*6070
 
   - it: restapi_port correct with non-default port
@@ -19,7 +19,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: \s+restapi_port\s*=\s*4270
 
   - it: admin_variables.restapi_port specified directly does not cause duplicate setting
@@ -32,7 +32,7 @@ tests:
 
     asserts:
       - notMatchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: |
             (\s+restapi_port\s*=\s*4270
             .*){2,}

--- a/dysnix/proxysql/tests/configmap-include-directives_test.yaml
+++ b/dysnix/proxysql/tests/configmap-include-directives_test.yaml
@@ -10,12 +10,12 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: '@include "/etc/proxysql/secrets/admin_vars\.cnf"'
 
       # our includes should replace the insecure creds include
       - notMatchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: '@include "/etc/proxysql/admin_credentials\.cnf"'
 
   - it: mysql_variables include
@@ -25,7 +25,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: '@include "/etc/proxysql/secrets/mysql_vars\.cnf"'
 
   - it: mysql_users include
@@ -35,5 +35,5 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           pattern: '@include "/etc/proxysql/secrets/mysql_users\.cnf"'

--- a/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
+++ b/dysnix/proxysql/tests/configmap-proxysql-servers_test.yaml
@@ -13,7 +13,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           # NOTE: the renderer organizes the keys in alphabetical order
           pattern: |
             \s+hostname="foobar-test-core-0.foobar-test-core"
@@ -30,7 +30,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           # NOTE: the renderer organizes the keys in alphabetical order
           pattern: |
             \s+hostname="foobar-test-core-0.foobar-override"

--- a/dysnix/proxysql/tests/configmap-scheduler_test.yaml
+++ b/dysnix/proxysql/tests/configmap-scheduler_test.yaml
@@ -10,7 +10,7 @@ tests:
 
     asserts:
       - matchRegex:
-          path: data.[proxysql.cnf]
+          path: data["proxysql.cnf"]
           # NOTE: the renderer organizes the keys in alphabetical order
           pattern: |
             \s+active=1

--- a/dysnix/proxysql/tests/service-selector_test.yaml
+++ b/dysnix/proxysql/tests/service-selector_test.yaml
@@ -1,0 +1,34 @@
+suite: service
+templates:
+  - service.yaml
+
+tests:
+  - it: satellite enabled, base name
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+      proxysql_cluster.satellite.enabled: true
+
+    asserts:
+      - template: service.yaml
+        documentIndex: 0
+        equal:
+          path: spec.selector.app
+          value: proxysql
+
+  - it: satellite disabled, name with -core suffix
+    values:
+      - ./values/common.yaml
+    set:
+      proxysql_cluster.enabled: true
+      proxysql_cluster.core.enabled: true
+      proxysql_cluster.satellite.enabled: false
+
+    asserts:
+      - template: service.yaml
+        documentIndex: 0
+        equal:
+          path: spec.selector.app
+          value: proxysql-core


### PR DESCRIPTION
basically when we are only using core, the ClusterIP should use `app: {{ include "proxysql.name" . }}-core` in the selector.
It will give us a working ClusterIP service

updating helmunittest + fixing test dur to changes in the version