### PR TITLE
SRENG-26696 - Improve graceful shutdown support for ProxySQL

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.4-splashthat-rc1
+version: 0.10.5-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -14,10 +14,18 @@ PAUSE_TIMEOUT="${PROXYSQL_PAUSE_TIMEOUT:-10}"
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
   echo "Executing PROXYSQL PAUSE..."
 
-  export MYSQL_PWD="${PROXYSQL_ADMIN_PASSWORD}"
+  MYSQL_DEFAULTS=$(mktemp)
+  chmod 600 "${MYSQL_DEFAULTS}"
+  cat > "${MYSQL_DEFAULTS}" <<EOF
+[client]
+password=${PROXYSQL_ADMIN_PASSWORD}
+EOF
+
   timeout "${PAUSE_TIMEOUT}" \
-    mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
+    mysql --defaults-extra-file="${MYSQL_DEFAULTS}" -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
   pause_exit=$?
+
+  rm -f "${MYSQL_DEFAULTS}"
 
   if [ "${pause_exit}" -eq 0 ]; then
     echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -7,17 +7,29 @@
 
 set -u
 
+PAUSE_TIMEOUT="${PROXYSQL_PAUSE_TIMEOUT:-10}"
+
 # Pause ProxySQL to kill idle connections and close listeners before draining.
 # Requires PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD env vars.
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
   echo "Executing PROXYSQL PAUSE..."
-  mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -p"${PROXYSQL_ADMIN_PASSWORD}" -e "PROXYSQL PAUSE"
-  echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."
+
+  timeout "${PAUSE_TIMEOUT}" \
+    MYSQL_PWD="${PROXYSQL_ADMIN_PASSWORD}" mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
+  pause_exit=$?
+
+  if [ "${pause_exit}" -eq 0 ]; then
+    echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."
+  elif [ "${pause_exit}" -eq 124 ]; then
+    echo "WARNING: PROXYSQL PAUSE timed out after ${PAUSE_TIMEOUT}s. Continuing shutdown without pause."
+  else
+    echo "WARNING: PROXYSQL PAUSE failed (exit code ${pause_exit}). Continuing shutdown without pause."
+  fi
 else
   echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set, skipping PROXYSQL PAUSE"
 fi
 
-echo "Waiting for proxy queries to finish..."
+echo "Waiting for active proxy queries to finish..."
 
 while true; do
   CONNECTED_IPS=$(for pid in $(pidof proxysql); do \

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -7,38 +7,51 @@
 
 set -u
 
-PAUSE_TIMEOUT="${PROXYSQL_PAUSE_TIMEOUT:-10}"
+# Runs a SQL command against the ProxySQL admin interface.
+# Handles credential file creation/cleanup and timeout.
+proxysql_admin() {
+  local sql="$1"
+  local admin_port="${PROXYSQL_ADMIN_PORT:-6032}"
+  local pause_timeout="${PROXYSQL_PAUSE_TIMEOUT:-10}"
 
-# Pause ProxySQL to kill idle connections and close listeners before draining.
+  local creds
+  creds=$(mktemp)
+  chmod 600 "${creds}"
+  printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${creds}"
+
+  timeout "${pause_timeout}" \
+    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
+  local rc=$?
+
+  rm -f "${creds}"
+  return "${rc}"
+}
+
+# Executes PROXYSQL PAUSE to kill idle connections and close listeners.
 # Requires PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD env vars.
-if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
+pause_proxysql() {
+  local pause_timeout="${PROXYSQL_PAUSE_TIMEOUT:-10}"
+
   echo "Executing PROXYSQL PAUSE..."
+  proxysql_admin "PROXYSQL PAUSE"
+  local rc=$?
 
-  MYSQL_DEFAULTS=$(mktemp)
-  chmod 600 "${MYSQL_DEFAULTS}"
-  cat > "${MYSQL_DEFAULTS}" <<EOF
-[client]
-password=${PROXYSQL_ADMIN_PASSWORD}
-EOF
-
-  timeout "${PAUSE_TIMEOUT}" \
-    mysql --defaults-extra-file="${MYSQL_DEFAULTS}" -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
-  pause_exit=$?
-
-  rm -f "${MYSQL_DEFAULTS}"
-
-  if [ "${pause_exit}" -eq 0 ]; then
+  if [ "${rc}" -eq 0 ]; then
     echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."
-  elif [ "${pause_exit}" -eq 124 ]; then
-    echo "WARNING: PROXYSQL PAUSE timed out after ${PAUSE_TIMEOUT}s. Continuing shutdown without pause."
+  elif [ "${rc}" -eq 124 ]; then
+    echo "WARNING: PROXYSQL PAUSE timed out after ${pause_timeout}s. Continuing shutdown without pause."
   else
-    echo "WARNING: PROXYSQL PAUSE failed (exit code ${pause_exit}). Continuing shutdown without pause."
+    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc}). Continuing shutdown without pause."
   fi
+}
+
+if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
+  pause_proxysql
 else
   echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set, skipping PROXYSQL PAUSE"
 fi
 
-echo "Waiting for active proxy queries to finish..."
+echo "Waiting for active queries to finish..."
 
 while true; do
   CONNECTED_IPS=$(for pid in $(pidof proxysql); do \

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -7,6 +7,16 @@
 
 set -u
 
+# Pause ProxySQL to kill idle connections and close listeners before draining.
+# Requires PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD env vars.
+if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
+  echo "Executing PROXYSQL PAUSE..."
+  mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -p"${PROXYSQL_ADMIN_PASSWORD}" -e "PROXYSQL PAUSE"
+  echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."
+else
+  echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set, skipping PROXYSQL PAUSE"
+fi
+
 echo "Waiting for proxy queries to finish..."
 
 while true; do

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -20,7 +20,7 @@ proxysql_admin() {
   printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${creds}"
 
   timeout "${pause_timeout}" \
-    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
+    mysql --defaults-extra-file="${creds}" --ssl-mode=DISABLED -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
   local rc=$?
 
   rm -f "${creds}"

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -20,7 +20,7 @@ proxysql_admin() {
   printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${creds}"
 
   timeout "${pause_timeout}" \
-    mysql --defaults-extra-file="${creds}" --ssl-mode=DISABLED -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
+    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
   local rc=$?
 
   rm -f "${creds}"

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -14,8 +14,9 @@ PAUSE_TIMEOUT="${PROXYSQL_PAUSE_TIMEOUT:-10}"
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
   echo "Executing PROXYSQL PAUSE..."
 
+  export MYSQL_PWD="${PROXYSQL_ADMIN_PASSWORD}"
   timeout "${PAUSE_TIMEOUT}" \
-    MYSQL_PWD="${PROXYSQL_ADMIN_PASSWORD}" mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
+    mysql -h127.0.0.1 -P"${PROXYSQL_ADMIN_PORT:-6032}" -u"${PROXYSQL_ADMIN_USER}" -e "PROXYSQL PAUSE"
   pause_exit=$?
 
   if [ "${pause_exit}" -eq 0 ]; then

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -37,18 +37,18 @@ pause_proxysql() {
   local rc=$?
 
   if [ "${rc}" -eq 0 ]; then
-    echo "PROXYSQL PAUSE complete. Idle connections terminated, listeners closed."
+    echo "PROXYSQL PAUSE complete. Idle connections terminated, no new connections accepted."
   elif [ "${rc}" -eq 124 ]; then
-    echo "WARNING: PROXYSQL PAUSE timed out after ${pause_timeout}s. Continuing shutdown without pause."
+    echo "WARNING: PROXYSQL PAUSE timed out after ${pause_timeout}s. Idle connections may prevent graceful shutdown and be killed by SIGKILL."
   else
-    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc}). Continuing shutdown without pause."
+    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc}). Idle connections may prevent graceful shutdown and be killed by SIGKILL."
   fi
 }
 
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
   pause_proxysql
 else
-  echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set, skipping PROXYSQL PAUSE"
+  echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set. Idle connections may prevent graceful shutdown and be killed by SIGKILL."
 fi
 
 echo "Waiting for active queries to finish..."

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -59,10 +59,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.gracefulShutdown.envSecretName }}
+          {{- with .Values.envFrom }}
           envFrom:
-            - secretRef:
-                name: {{ .Values.gracefulShutdown.envSecretName }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           lifecycle:
             preStop:

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -59,6 +59,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.gracefulShutdown.envSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.gracefulShutdown.envSecretName }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -60,6 +60,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.gracefulShutdown.envSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.gracefulShutdown.envSecretName }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -60,10 +60,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.gracefulShutdown.envSecretName }}
+          {{- with .Values.envFrom }}
           envFrom:
-            - secretRef:
-                name: {{ .Values.gracefulShutdown.envSecretName }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           lifecycle:
             preStop:

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -61,6 +61,11 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.gracefulShutdown.envSecretName }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.gracefulShutdown.envSecretName }}
+          {{- end }}
           lifecycle:
             preStop:
               exec:

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -61,10 +61,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ template "proxysql.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.gracefulShutdown.envSecretName }}
+          {{- with .Values.envFrom }}
           envFrom:
-            - secretRef:
-                name: {{ .Values.gracefulShutdown.envSecretName }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           lifecycle:
             preStop:

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -34,11 +34,9 @@ volumeMounts: []
 #   - name: secret-confs
 #     mountPath: /etc/proxysql/secrets
 
-## Name of a Kubernetes Secret containing PROXYSQL_ADMIN_USER and
-## PROXYSQL_ADMIN_PASSWORD env vars. When set, the pre-stop hook
-## runs PROXYSQL PAUSE to gracefully drain connections on shutdown.
-gracefulShutdown:
-  envSecretName: ""
+## Environment sources to inject into the ProxySQL container.
+## Each entry follows the Kubernetes envFrom spec (secretRef, configMapRef).
+envFrom: []
 
 podSecurityContext:
   runAsNonRoot: true

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -34,6 +34,12 @@ volumeMounts: []
 #   - name: secret-confs
 #     mountPath: /etc/proxysql/secrets
 
+## Name of a Kubernetes Secret containing PROXYSQL_ADMIN_USER and
+## PROXYSQL_ADMIN_PASSWORD env vars. When set, the pre-stop hook
+## runs PROXYSQL PAUSE to gracefully drain connections on shutdown.
+gracefulShutdown:
+  envSecretName: ""
+
 podSecurityContext:
   runAsNonRoot: true
   fsGroup: 999


### PR DESCRIPTION
Updates shutdown script to include a call to `PROXYSQL PAUSE` to terminate idle connections (and other things): [ref](https://proxysql.com/documentation/the-admin-schemas/#:~:text=mysql%2Dwait_timeout%20is%20set%20to%200%3B%20any%20idle%20connection%2C%20not%20in%20a%20transaction%2C%20is%20immediately%20closed)

Adds top-level `envFrom` to `values.yaml`