### PR TITLE
SRENG-22827 - Update preStop script to execute wait_timeout=0 explicitly

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.5-splashthat-rc1
+version: 0.10.6-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -32,17 +32,27 @@ proxysql_admin() {
 # so we set it explicitly to close idle connections immediately.
 drain_proxysql() {
   echo "Executing PROXYSQL PAUSE..."
-  if proxysql_admin "PROXYSQL PAUSE"; then
+  proxysql_admin "PROXYSQL PAUSE"
+  local rc=$?
+
+  if [ "${rc}" -eq 0 ]; then
     echo "PROXYSQL PAUSE complete. No new connections accepted."
+  elif [ "${rc}" -eq 124 ]; then
+    echo "WARNING: PROXYSQL PAUSE timed out after ${ADMIN_TIMEOUT}s (exit code ${rc})."
   else
-    echo "WARNING: PROXYSQL PAUSE failed or timed out."
+    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc})."
   fi
 
   echo "Setting mysql-wait_timeout=0 to close idle connections..."
-  if proxysql_admin "SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME;"; then
+  proxysql_admin "SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME;"
+  local wt_rc=$?
+
+  if [ "${wt_rc}" -eq 0 ]; then
     echo "mysql-wait_timeout=0 applied. Idle connections will be closed immediately."
+  elif [ "${wt_rc}" -eq 124 ]; then
+    echo "WARNING: Setting wait_timeout timed out after ${ADMIN_TIMEOUT}s (exit code ${wt_rc})."
   else
-    echo "WARNING: Setting wait_timeout failed. Idle connections may persist until SIGKILL."
+    echo "WARNING: Setting wait_timeout failed (exit code ${wt_rc}). Idle connections may persist until SIGKILL."
   fi
 }
 

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -7,28 +7,28 @@ set -u
 
 ADMIN_PORT="${PROXYSQL_ADMIN_PORT:-6032}"
 ADMIN_TIMEOUT="${PROXYSQL_ADMIN_TIMEOUT:-10}"
+ADMIN_CREDS=""
+
+# Creates the MySQL credentials file once for the lifetime of the script.
+init_admin_creds() {
+  ADMIN_CREDS=$(mktemp) || { echo "ERROR: mktemp failed."; return 1; }
+  chmod 600 "${ADMIN_CREDS}"
+  printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${ADMIN_CREDS}"
+  trap 'rm -f "${ADMIN_CREDS}"' EXIT
+}
 
 # Runs a SQL command against the ProxySQL admin interface.
 # Output is raw (no headers/formatting) for easy parsing.
 proxysql_admin() {
   local sql="$1"
 
-  local creds
-  creds=$(mktemp)
-  chmod 600 "${creds}"
-  printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${creds}"
-
   timeout "${ADMIN_TIMEOUT}" \
-    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${ADMIN_PORT}" \
+    mysql --defaults-extra-file="${ADMIN_CREDS}" -h127.0.0.1 -P"${ADMIN_PORT}" \
       -u"${PROXYSQL_ADMIN_USER}" -sN -e "${sql}"
-  local rc=$?
-
-  rm -f "${creds}"
-  return "${rc}"
 }
 
 # Stops listeners and kills idle connections.
-# PAUSE alone does NOT set wait_timeout=0 (removed in ProxySQL v1.4.1),
+# PAUSE alone does NOT set wait_timeout=0 (removed in ProxySQL v1.4.1 https://github.com/sysown/proxysql/issues/2484#issuecomment-574092954),
 # so we set it explicitly to close idle connections immediately.
 drain_proxysql() {
   echo "Executing PROXYSQL PAUSE..."
@@ -38,9 +38,11 @@ drain_proxysql() {
   if [ "${rc}" -eq 0 ]; then
     echo "PROXYSQL PAUSE complete. No new connections accepted."
   elif [ "${rc}" -eq 124 ]; then
-    echo "WARNING: PROXYSQL PAUSE timed out after ${ADMIN_TIMEOUT}s (exit code ${rc})."
+    echo "WARNING: PROXYSQL PAUSE timed out after ${ADMIN_TIMEOUT}s (exit code ${rc}). New connections may still be accepted."
+    return 1
   else
-    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc})."
+    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc}). New connections may still be accepted."
+    return 1
   fi
 
   echo "Setting mysql-wait_timeout=0 to close idle connections..."
@@ -57,6 +59,7 @@ drain_proxysql() {
 }
 
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
+  init_admin_creds
   drain_proxysql
 else
   echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set. Idle connections may persist until SIGKILL."

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -59,8 +59,7 @@ drain_proxysql() {
 }
 
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
-  init_admin_creds
-  drain_proxysql
+  init_admin_creds && drain_proxysql
 else
   echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set. Idle connections may persist until SIGKILL."
 fi

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -1,54 +1,55 @@
 #!/usr/bin/env bash
 
-# For all proxysql processes iterate over all tcp connections
-# and search for any established connection to port ${PROXYSQL_SERVICE_PORT_PROXY:-6033}.
-# If more than one connection is found, randomly sleep up to 3 seconds,
-# otherwise exit 0.
+# Pre-stop hook for ProxySQL: drains connections and waits for active queries
+# to finish before allowing the pod to terminate.
 
 set -u
 
+ADMIN_PORT="${PROXYSQL_ADMIN_PORT:-6032}"
+ADMIN_TIMEOUT="${PROXYSQL_ADMIN_TIMEOUT:-10}"
+
 # Runs a SQL command against the ProxySQL admin interface.
-# Handles credential file creation/cleanup and timeout.
+# Output is raw (no headers/formatting) for easy parsing.
 proxysql_admin() {
   local sql="$1"
-  local admin_port="${PROXYSQL_ADMIN_PORT:-6032}"
-  local pause_timeout="${PROXYSQL_PAUSE_TIMEOUT:-10}"
 
   local creds
   creds=$(mktemp)
   chmod 600 "${creds}"
   printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${creds}"
 
-  timeout "${pause_timeout}" \
-    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${admin_port}" -u"${PROXYSQL_ADMIN_USER}" -e "${sql}"
+  timeout "${ADMIN_TIMEOUT}" \
+    mysql --defaults-extra-file="${creds}" -h127.0.0.1 -P"${ADMIN_PORT}" \
+      -u"${PROXYSQL_ADMIN_USER}" -sN -e "${sql}"
   local rc=$?
 
   rm -f "${creds}"
   return "${rc}"
 }
 
-# Executes PROXYSQL PAUSE to kill idle connections and close listeners.
-# Requires PROXYSQL_ADMIN_USER and PROXYSQL_ADMIN_PASSWORD env vars.
-pause_proxysql() {
-  local pause_timeout="${PROXYSQL_PAUSE_TIMEOUT:-10}"
-
+# Stops listeners and kills idle connections.
+# PAUSE alone does NOT set wait_timeout=0 (removed in ProxySQL v1.4.1),
+# so we set it explicitly to close idle connections immediately.
+drain_proxysql() {
   echo "Executing PROXYSQL PAUSE..."
-  proxysql_admin "PROXYSQL PAUSE"
-  local rc=$?
-
-  if [ "${rc}" -eq 0 ]; then
-    echo "PROXYSQL PAUSE complete. Idle connections terminated, no new connections accepted."
-  elif [ "${rc}" -eq 124 ]; then
-    echo "WARNING: PROXYSQL PAUSE timed out after ${pause_timeout}s. Idle connections may prevent graceful shutdown and be killed by SIGKILL."
+  if proxysql_admin "PROXYSQL PAUSE"; then
+    echo "PROXYSQL PAUSE complete. No new connections accepted."
   else
-    echo "WARNING: PROXYSQL PAUSE failed (exit code ${rc}). Idle connections may prevent graceful shutdown and be killed by SIGKILL."
+    echo "WARNING: PROXYSQL PAUSE failed or timed out."
+  fi
+
+  echo "Setting mysql-wait_timeout=0 to close idle connections..."
+  if proxysql_admin "SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME;"; then
+    echo "mysql-wait_timeout=0 applied. Idle connections will be closed immediately."
+  else
+    echo "WARNING: Setting wait_timeout failed. Idle connections may persist until SIGKILL."
   fi
 }
 
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then
-  pause_proxysql
+  drain_proxysql
 else
-  echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set. Idle connections may prevent graceful shutdown and be killed by SIGKILL."
+  echo "WARNING: PROXYSQL_ADMIN_USER or PROXYSQL_ADMIN_PASSWORD not set. Idle connections may persist until SIGKILL."
 fi
 
 echo "Waiting for active queries to finish..."


### PR DESCRIPTION
Ticket: https://jira.cvent.com/browse/SRENG-22827

Updates the script to;
- Explicitly execute `wait_timeout=0`
  - We were under the impression this was done by ProxySQL ([due to docs](https://proxysql.com/documentation/the-admin-schemas/#:~:text=mysql%2Dwait_timeout%20is%20set%20to%200%3B%20any%20idle%20connection%2C%20not%20in%20a%20transaction%2C%20is%20immediately%20closed)) but turns out it was removed (see issue in script comment)
- Refactors the script a bit
  - Create creds file once at the start and clean up on script exit