### PR TITLE
Replace wait_timeout=0 with idle session kills

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.6-splashthat-rc1
+version: 0.10.7-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -55,15 +55,41 @@ drain_proxysql() {
 
   echo "Killing idle frontend sessions on this pod..."
   local idle_ids
+  local kill_sql=""
+  local killed=0
+  local rc
   # 'Sleep' — session is connected and waiting for the next client command.
   #           https://github.com/sysown/proxysql/blob/v2.4.4/lib/MySQL_Thread.cpp#L4786
   #           ProxySQL processlist docs:
   #           https://proxysql.com/documentation/the-admin-schemas/stats/stats-mysql#stats_mysql_processlist
   idle_ids=$(proxysql_admin "SELECT SessionID FROM stats_mysql_processlist WHERE command = 'Sleep'")
-  local killed=0
+  rc=$?
+  if [ "${rc}" -eq 124 ]; then
+    echo "WARNING: Query for idle sessions timed out after ${ADMIN_TIMEOUT}s. Idle connections may persist."
+    return 1
+  elif [ "${rc}" -ne 0 ]; then
+    echo "WARNING: Query for idle sessions failed (exit code ${rc}). Idle connections may persist."
+    return 1
+  fi
   for sid in ${idle_ids}; do
-    proxysql_admin "KILL CONNECTION ${sid}" >/dev/null 2>&1 && killed=$((killed + 1))
+    kill_sql="${kill_sql}KILL CONNECTION ${sid}; "
+    killed=$((killed + 1))
   done
+
+  if [ "${killed}" -eq 0 ]; then
+    echo "Killed 0 idle session(s)."
+    return 0
+  fi
+
+  proxysql_admin "${kill_sql}" >/dev/null 2>&1
+  rc=$?
+  if [ "${rc}" -eq 124 ]; then
+    echo "WARNING: Killing ${killed} idle session(s) timed out after ${ADMIN_TIMEOUT}s. Some may persist."
+    return 1
+  elif [ "${rc}" -ne 0 ]; then
+    echo "WARNING: Killing ${killed} idle session(s) failed (exit code ${rc}). Some may persist."
+    return 1
+  fi
   echo "Killed ${killed} idle session(s)."
 }
 

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -81,7 +81,7 @@ drain_proxysql() {
     return 0
   fi
 
-  proxysql_admin "${kill_sql}" >/dev/null 2>&1
+  proxysql_admin "${kill_sql}"
   rc=$?
   if [ "${rc}" -eq 124 ]; then
     echo "WARNING: Killing ${killed} idle session(s) timed out after ${ADMIN_TIMEOUT}s. Some may persist."

--- a/dysnix/proxysql/files/wait_queries_to_finish.sh
+++ b/dysnix/proxysql/files/wait_queries_to_finish.sh
@@ -11,9 +11,12 @@ ADMIN_CREDS=""
 
 # Creates the MySQL credentials file once for the lifetime of the script.
 init_admin_creds() {
-  ADMIN_CREDS=$(mktemp) || { echo "ERROR: mktemp failed."; return 1; }
+  ADMIN_CREDS=$(mktemp) || {
+    echo "ERROR: mktemp failed."
+    return 1
+  }
   chmod 600 "${ADMIN_CREDS}"
-  printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" > "${ADMIN_CREDS}"
+  printf '[client]\npassword=%s\n' "${PROXYSQL_ADMIN_PASSWORD}" >"${ADMIN_CREDS}"
   trap 'rm -f "${ADMIN_CREDS}"' EXIT
 }
 
@@ -24,12 +27,17 @@ proxysql_admin() {
 
   timeout "${ADMIN_TIMEOUT}" \
     mysql --defaults-extra-file="${ADMIN_CREDS}" -h127.0.0.1 -P"${ADMIN_PORT}" \
-      -u"${PROXYSQL_ADMIN_USER}" -sN -e "${sql}"
+    -u"${PROXYSQL_ADMIN_USER}" -sN -e "${sql}"
 }
 
-# Stops listeners and kills idle connections.
-# PAUSE alone does NOT set wait_timeout=0 (removed in ProxySQL v1.4.1 https://github.com/sysown/proxysql/issues/2484#issuecomment-574092954),
-# so we set it explicitly to close idle connections immediately.
+# Stops listeners and kills idle frontend sessions on THIS pod only.
+# PAUSE alone does NOT close idle connections (wait_timeout=0 behavior was removed in ProxySQL v1.4.1
+# https://github.com/sysown/proxysql/issues/2484#issuecomment-574092954).
+# We use KILL CONNECTION per session instead of SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME
+# because LOAD TO RUNTIME triggers cluster sync and propagates wait_timeout=0 to all peers,
+# killing idle connections cluster-wide and causing "MySQL server has gone away" storms.
+# KILL CONNECTION is admin-scoped: it does not modify mysql_variables, so no checksum change
+# and no cluster replication occurs.
 drain_proxysql() {
   echo "Executing PROXYSQL PAUSE..."
   proxysql_admin "PROXYSQL PAUSE"
@@ -45,17 +53,18 @@ drain_proxysql() {
     return 1
   fi
 
-  echo "Setting mysql-wait_timeout=0 to close idle connections..."
-  proxysql_admin "SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME;"
-  local wt_rc=$?
-
-  if [ "${wt_rc}" -eq 0 ]; then
-    echo "mysql-wait_timeout=0 applied. Idle connections will be closed immediately."
-  elif [ "${wt_rc}" -eq 124 ]; then
-    echo "WARNING: Setting wait_timeout timed out after ${ADMIN_TIMEOUT}s (exit code ${wt_rc})."
-  else
-    echo "WARNING: Setting wait_timeout failed (exit code ${wt_rc}). Idle connections may persist until SIGKILL."
-  fi
+  echo "Killing idle frontend sessions on this pod..."
+  local idle_ids
+  # 'Sleep' — session is connected and waiting for the next client command.
+  #           https://github.com/sysown/proxysql/blob/v2.4.4/lib/MySQL_Thread.cpp#L4786
+  #           ProxySQL processlist docs:
+  #           https://proxysql.com/documentation/the-admin-schemas/stats/stats-mysql#stats_mysql_processlist
+  idle_ids=$(proxysql_admin "SELECT SessionID FROM stats_mysql_processlist WHERE command = 'Sleep'")
+  local killed=0
+  for sid in ${idle_ids}; do
+    proxysql_admin "KILL CONNECTION ${sid}" >/dev/null 2>&1 && killed=$((killed + 1))
+  done
+  echo "Killed ${killed} idle session(s)."
 }
 
 if [ -n "${PROXYSQL_ADMIN_USER:-}" ] && [ -n "${PROXYSQL_ADMIN_PASSWORD:-}" ]; then


### PR DESCRIPTION
## Summary

- Replace `SET mysql-wait_timeout=0; LOAD MYSQL VARIABLES TO RUNTIME` in `drain_proxysql()` with a pod-local `KILL CONNECTION` loop over `stats_mysql_processlist`
- The old approach triggered ProxySQL cluster sync, propagating `wait_timeout=0` to all surviving peers and killing idle connections cluster-wide — causing "MySQL server has gone away" storms on every pod shutdown
- `KILL CONNECTION` sends TCP FIN to each idle session on the shutting-down pod only; it does not modify `mysql_variables`, so no checksum change occurs and peers never replicate

## Root cause

`LOAD MYSQL VARIABLES TO RUNTIME` updates the runtime checksum. ProxySQL cluster mode detects the delta and replicates to all peers, which also write the new value to disk. One pod's pre-stop hook was silently resetting `mysql-wait_timeout=0` across the entire cluster on every pod cycle.