### PR TITLE
Update stdout redirect to write to proxysql tailed pid to fix missing logs

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.7-splashthat-rc1
+version: 0.10.8-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1 2>&1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}

--- a/dysnix/proxysql/templates/daemonset.yaml
+++ b/dysnix/proxysql/templates/daemonset.yaml
@@ -66,7 +66,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1 2>&1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}

--- a/dysnix/proxysql/templates/deployment.yaml
+++ b/dysnix/proxysql/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/1/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1"]
+                command: ["/bin/sh", "-c", "/usr/local/bin/wait_queries_to_finish.sh > /proc/$(pidof proxysql)/fd/1 2>&1"]
           ports:
             - name: proxy
               containerPort: {{ .Values.service.proxyPort }}


### PR DESCRIPTION
## Summary

PreStop output from `wait_queries_to_finish.sh` was being silently dropped instead of reaching observability tooling. The chart redirected script stdout to `/proc/1/fd/1`, but with `shareProcessNamespace: true` PID 1 is the pause container, whose fd 1 points to `/dev/null`. Verified empirically on a proxysql pod in a lower environment

- `/proc/1/fd/1 -> /dev/null`
- `/proc/$(pidof proxysql)/fd/1 -> pipe:[…]` (runtime log pipe)

A test write to proxysql's fd 1 appeared in `kubectl logs`, confirming the runtime tails it. Switching the redirect target to `/proc/$(pidof proxysql)/fd/1` in all three workload templates makes preStop output show up in container logs