### PR TITLE
feat(proxysql): update PDB to policy/v1 and add topologySpreadConstraints support

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.10-splashthat-rc1
+version: 0.10.9-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.9-splashthat-rc1
+version: 0.10.10-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.8-splashthat-rc1
+version: 0.10.9-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/templates/pdb.yaml
+++ b/dysnix/proxysql/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "proxysql.fullname" . }}

--- a/dysnix/proxysql/templates/statefulset.yaml
+++ b/dysnix/proxysql/templates/statefulset.yaml
@@ -166,6 +166,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with (default .Values.topologySpreadConstraints .Values.proxysql_cluster.core.statefulset.topologySpreadConstraints) }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with (default .Values.tolerations .Values.proxysql_cluster.core.statefulset.tolerations) }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -247,6 +247,14 @@ mysql_variables:
   # monitor_username: "monitor"
   # monitor_password: "monitor"
   # monitor_history: 600000
+  #
+  # Aurora failover tuning — enable alongside mysql_aws_aurora_hostgroups:
+  # monitor_ping_interval: 1000         # ms — ping backends every 1s
+  # monitor_ping_timeout: 200           # ms
+  # monitor_read_only_interval: 500     # ms — detect role changes within 500ms
+  # monitor_read_only_timeout: 500      # ms
+  # connect_timeout_server: 1000        # ms — stop routing to dead backends quickly
+  # connect_timeout_server_max: 3000    # ms
 
 ## A list of files to @include in the `mysql_variables` section
 ##
@@ -295,6 +303,30 @@ scheduler:
   #   interval_ms: 300000
   #   filename: "/usr/local/bin/cleanup-digest.bash"
   #   comment: "job to cleanup stats_mysql_query_digest table"
+
+## MySQL replication hostgroup mapping (traditional MySQL replication, not Aurora).
+## For Aurora clusters use mysql_aws_aurora_hostgroups instead.
+mysql_replication_hostgroups: []
+# - writer_hostgroup: 0
+#   reader_hostgroup: 1
+#   comment: "production"
+
+## AWS Aurora hostgroup configuration for automatic failover handling.
+## ProxySQL polls each instance's role via information_schema.replica_host_status
+## and automatically moves servers between writer/reader hostgroups on failover,
+## stopping traffic to instances that are rebooting or offline.
+## Requires monitor_enabled=true and a monitor user with REPLICATION CLIENT privilege.
+## ref: https://proxysql.com/documentation/proxysql-aws-aurora/
+mysql_aws_aurora_hostgroups: []
+# - writer_hostgroup: 0
+#   reader_hostgroup: 1
+#   active: 1
+#   aurora_port: 3306
+#   domain_name: ".cluster-<cluster-id>.us-east-1.rds.amazonaws.com"
+#   check_interval_ms: 500
+#   check_timeout_ms: 800
+#   max_lag_ms: 600000
+#   writer_is_also_reader: 1
 
 ## If enabled, generate automagically a list of proxysql servers based on the
 #    the number statefulset 'proxysql-core' replicas (default 3).

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -132,6 +132,10 @@ tolerations: []
 # Will be applied if not specified otherwise.
 affinity: {}
 
+# Default topology spread constraints.
+# Will be applied if not specified otherwise.
+topologySpreadConstraints: []
+
 # Common annotations to add to all resources (sub-charts are not considered).
 # Evaluated as a template
 commonAnnotations: {}
@@ -330,6 +334,7 @@ proxysql_cluster:
       nodeSelector: {}
       tolerations: []
       affinity: {}
+      topologySpreadConstraints: []
       podAnnotations: {}
 
       resources: {}


### PR DESCRIPTION
## Summary

- Upgrades PDB `apiVersion` from `policy/v1beta1` to `policy/v1` for Kubernetes 1.25+ compatibility
- Adds `topologySpreadConstraints` rendering to the StatefulSet core template, following the same `default`-override pattern as `affinity`, `tolerations`, and `nodeSelector`
- Adds `topologySpreadConstraints: []` defaults globally and under `proxysql_cluster.core.statefulset` in `values.yaml`
- Bumps chart version to `0.10.9-splashthat-rc1`

Closes [SRENG-31074](https://jira.cvent.com/browse/SRENG-31074)

## Test plan

- [x] `helm lint dysnix/proxysql` passes with 0 failures
- [x] `helm template` renders PDB with `apiVersion: policy/v1`
- [x] `helm template` renders `topologySpreadConstraints` in the StatefulSet when values are set

🤖 Generated with [Claude Code](https://claude.com/claude-code)