### PR TITLE
fix(proxysql): Setting  default minAvailable to null on  PDB template to prevent conflict with maxUnavailable

### DIFF
--- a/dysnix/proxysql/Chart.yaml
+++ b/dysnix/proxysql/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.5"
 description: ProxySQL Helm chart for Kubernetes
 name: proxysql
-version: 0.10.10-splashthat-rc1
+version: 0.10.11-splashthat-rc1
 home: https://www.proxysql.com/
 sources:
   - https://github.com/SplashThat/dysnix-charts

--- a/dysnix/proxysql/templates/pdb.yaml
+++ b/dysnix/proxysql/templates/pdb.yaml
@@ -15,6 +15,8 @@ metadata:
 spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- else if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
   selector:
     matchLabels:

--- a/dysnix/proxysql/templates/pdb.yaml
+++ b/dysnix/proxysql/templates/pdb.yaml
@@ -15,8 +15,6 @@ metadata:
 spec:
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
-{{- else if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
   selector:
     matchLabels:

--- a/dysnix/proxysql/templates/pdb.yaml
+++ b/dysnix/proxysql/templates/pdb.yaml
@@ -13,11 +13,10 @@ metadata:
     {{- toYaml .Values.commonAnnotations | nindent 4 }}
   {{- end }}
 spec:
-{{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-{{- end }}
 {{- if .Values.podDisruptionBudget.maxUnavailable }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- else if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
 {{- end }}
   selector:
     matchLabels:

--- a/dysnix/proxysql/values.yaml
+++ b/dysnix/proxysql/values.yaml
@@ -150,7 +150,7 @@ podLabels: {}
 ##
 podDisruptionBudget:
   enabled: false
-  minAvailable: 1
+  minAvailable: ~
   # maxUnavailable: 1
 
 readinessProbe:


### PR DESCRIPTION
## Problem

When `maxUnavailable` is set by callers, the dysnix chart default
`minAvailable: 1` was never cleared — Helm coalesces null overrides
away, so the default persisted. This caused both fields to render in
the PDB spec simultaneously, which Kubernetes rejects:

```
minAvailable and maxUnavailable cannot be both set
```

## Fix

Remove `minAvailable` from the PDB template entirely. Only
`maxUnavailable` is rendered. This avoids the conflict and aligns
with how we configure PDBs in our wrapper charts.

## Changes

- `dysnix/proxysql/templates/pdb.yaml` — removed `minAvailable` rendering
- `dysnix/proxysql/Chart.yaml` — bumped to `0.10.11-splashthat-rc1`